### PR TITLE
[Semaphore] allow redis cluster/sentinel dsn

### DIFF
--- a/src/Symfony/Component/Semaphore/Store/StoreFactory.php
+++ b/src/Symfony/Component/Semaphore/Store/StoreFactory.php
@@ -35,8 +35,8 @@ class StoreFactory
 
             case !\is_string($connection):
                 throw new InvalidArgumentException(sprintf('Unsupported Connection: "%s".', $connection::class));
-            case str_starts_with($connection, 'redis://'):
-            case str_starts_with($connection, 'rediss://'):
+            case str_starts_with($connection, 'redis:'):
+            case str_starts_with($connection, 'rediss:'):
                 if (!class_exists(AbstractAdapter::class)) {
                     throw new InvalidArgumentException('Unsupported Redis DSN. Try running "composer require symfony/cache".');
                 }

--- a/src/Symfony/Component/Semaphore/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/StoreFactoryTest.php
@@ -12,54 +12,37 @@
 namespace Symfony\Component\Semaphore\Tests\Store;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Semaphore\Store\RedisStore;
 use Symfony\Component\Semaphore\Store\StoreFactory;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @requires extension redis
  */
 class StoreFactoryTest extends TestCase
 {
-    public function testCreateRedisStore()
+    /**
+     * @dataProvider validConnections
+     */
+    public function testCreateStore($connection, string $expectedStoreClass)
     {
-        $store = StoreFactory::createStore($this->createMock(\Redis::class));
+        $store = StoreFactory::createStore($connection);
 
-        $this->assertInstanceOf(RedisStore::class, $store);
+        $this->assertInstanceOf($expectedStoreClass, $store);
     }
 
-    public function testCreateRedisProxyStore()
+    public static function validConnections(): \Generator
     {
-        if (!class_exists(RedisProxy::class)) {
-            $this->markTestSkipped();
+        yield [new \Predis\Client(), RedisStore::class];
+
+        if (class_exists(\Redis::class)) {
+            yield [new \Redis(), RedisStore::class];
         }
-
-        $store = StoreFactory::createStore($this->createMock(RedisProxy::class));
-
-        $this->assertInstanceOf(RedisStore::class, $store);
-    }
-
-    public function testCreateRedisAsDsnStore()
-    {
-        if (!class_exists(RedisProxy::class)) {
-            $this->markTestSkipped();
+        if (class_exists(\Redis::class) && class_exists(AbstractAdapter::class)) {
+            yield ['redis://localhost', RedisStore::class];
+            yield ['redis://localhost?lazy=1', RedisStore::class];
+            yield ['redis://localhost?redis_cluster=1', RedisStore::class];
+            yield ['redis://localhost?redis_cluster=1&lazy=1', RedisStore::class];
+            yield ['redis:?host[localhost]&host[localhost:6379]&redis_cluster=1', RedisStore::class];
         }
-
-        $store = StoreFactory::createStore('redis://localhost');
-
-        $this->assertInstanceOf(RedisStore::class, $store);
-    }
-
-    public function testCreatePredisStore()
-    {
-        if (!class_exists(\Predis\Client::class)) {
-            $this->markTestSkipped();
-        }
-
-        $store = StoreFactory::createStore(new \Predis\Client());
-
-        $this->assertInstanceOf(RedisStore::class, $store);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | -
| License       | MIT

This PR allows to use redis cluster/sentinel DSN for configuration. It syncs the same behaviour from [Lock Component StoreFactory](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Lock/Store/StoreFactory.php#L63).
